### PR TITLE
added new location where keyrings are commonly initialized.

### DIFF
--- a/Deja.Crypto/BcPgp/CryptoContext.cs
+++ b/Deja.Crypto/BcPgp/CryptoContext.cs
@@ -63,6 +63,11 @@ namespace Deja.Crypto.BcPgp
 			gpgHome = Path.Combine(gpgHome, "gnupg");
 			gpgLocations.Add(gpgHome);
 
+			// many systems also use C:\Users\[name]\.gnupg as well.
+			gpgHome = System.Environment.GetEnvironmentVariable("USERPROFILE");
+			gpgHome = Path.Combine(gpgHome, "./gnupg");
+			gpgLocations.Add(gpgHome);
+
 			// Try all possible locations
 			foreach(var home in gpgLocations)
 			{

--- a/Deja.Crypto/BcPgp/CryptoContext.cs
+++ b/Deja.Crypto/BcPgp/CryptoContext.cs
@@ -73,16 +73,16 @@ namespace Deja.Crypto.BcPgp
 			{
 				if (File.Exists(Path.Combine(home, _privateFilename)))
 				{
-					PublicKeyRingFile = Path.Combine(gpgHome, _publicFilename);
-					PrivateKeyRingFile = Path.Combine(gpgHome, _privateFilename);
+					PublicKeyRingFile = Path.Combine(home, _publicFilename);
+					PrivateKeyRingFile = Path.Combine(home, _privateFilename);
 					return;
 				}
 
 				// Portable gnupg will use a subfolder named 'home'
 				if (File.Exists(Path.Combine(home, "home", _privateFilename)))
 				{
-					PublicKeyRingFile = Path.Combine(gpgHome, "home", _publicFilename);
-					PrivateKeyRingFile = Path.Combine(gpgHome, "home", _privateFilename);
+					PublicKeyRingFile = Path.Combine(home, "home", _publicFilename);
+					PrivateKeyRingFile = Path.Combine(home, "home", _privateFilename);
 					return;
 				}
 			}

--- a/Deja.Crypto/BcPgp/CryptoContext.cs
+++ b/Deja.Crypto/BcPgp/CryptoContext.cs
@@ -65,7 +65,7 @@ namespace Deja.Crypto.BcPgp
 
 			// many systems also use C:\Users\[name]\.gnupg as well.
 			gpgHome = System.Environment.GetEnvironmentVariable("USERPROFILE");
-			gpgHome = Path.Combine(gpgHome, "./gnupg");
+			gpgHome = Path.Combine(gpgHome, ".gnupg");
 			gpgLocations.Add(gpgHome);
 
 			// Try all possible locations

--- a/Deja.Crypto/BcPgp/PgpCrypto.cs
+++ b/Deja.Crypto/BcPgp/PgpCrypto.cs
@@ -236,8 +236,10 @@ namespace Deja.Crypto.BcPgp
 
 									foreach (string id in pubKey.GetUserIds())
 									{
-                                        if (!keyUserIds.Contains(pubKey))
-                                            keyUserIds.Add(pubKey);
+										if (!keyUserIds.Contains(pubKey))
+										{
+											keyUserIds.Add(pubKey);
+										}
 									}
 								}
 							}

--- a/Deja.Crypto/BcPgp/PgpCrypto.cs
+++ b/Deja.Crypto/BcPgp/PgpCrypto.cs
@@ -236,8 +236,8 @@ namespace Deja.Crypto.BcPgp
 
 									foreach (string id in pubKey.GetUserIds())
 									{
-										if (!keyUserIds.Contains(k))
-											keyUserIds.Add(k);
+                                        if (!keyUserIds.Contains(pubKey))
+                                            keyUserIds.Add(pubKey);
 									}
 								}
 							}


### PR DESCRIPTION
I'm running a key signing party at microsoft today, and I have been trying to get PGP set up on outlook so that I can show people how to use it. I've found that the default location for GPG on our windows 8 and 10 machines is "C:\Users\[name]\.gnupg\" rather than "C:\Users\[name]\AppData\Roaming\gnupg\". 